### PR TITLE
Improve multicursor example

### DIFF
--- a/multicursor/index.html
+++ b/multicursor/index.html
@@ -18,6 +18,7 @@
         top: 10px;
         right: 10px;
         z-index: 1;
+        border: 1px solid black;
       }
 
       .cursor {

--- a/multicursor/index.html
+++ b/multicursor/index.html
@@ -46,7 +46,7 @@
 
   <body>
     <div>
-      <button id="stop-cursor">Stop sending cursor events</button>
+      <button id="cursor-events-toggle">Stop sending cursor events</button>
     </div>
     <div id="hb-mini-container"></div>
     <div id="hb-large-container"></div>
@@ -74,7 +74,9 @@
       import Hyperbeam from "https://unpkg.com/@hyperbeam/web@latest/dist/index.js";
 
       const cursorNode = document.querySelector(".cursor");
-      const stopCursorEvents = document.getElementById("stop-cursor");
+      const cursorEventsToggle = document.getElementById(
+        "cursor-events-toggle"
+      );
       const largeContainer = document.getElementById("hb-large-container");
       const miniContainer = document.getElementById("hb-mini-container");
 
@@ -91,13 +93,14 @@
         const rect = container.getBoundingClientRect();
         const cursors = new Map();
         let cursorOn = true;
-        stopCursorEvents.addEventListener("click", () => {
+
+        cursorEventsToggle.addEventListener("click", () => {
           if (cursorOn) {
-            stopCursorEvents.innerText = "Start sending cursor events";
+            cursorEventsToggle.innerText = "Start sending cursor events";
             disableInput(container);
             cursorOn = false;
           } else {
-            stopCursorEvents.innerText = "Stop sending cursor events";
+            cursorEventsToggle.innerText = "Stop sending cursor events";
             enableInput(container);
             cursorOn = true;
           }

--- a/multicursor/index.html
+++ b/multicursor/index.html
@@ -119,7 +119,6 @@
                 ? container.offsetHeight * hbAspectRatio
                 : container.offsetWidth;
             const hbOffsetHeight = hbOffsetWidth / hbAspectRatio;
-
             const updateCursor = cursors.get(userId);
             const position = [
               hbOffsetWidth * x +
@@ -133,19 +132,24 @@
           },
         });
       }
+
       function newCursor(userId, cursors) {
         const elm = cursorNode.cloneNode(true);
         elm.classList.remove("hidden");
         document.body.appendChild(elm);
+
         const onCloseTimeout = () => {
           cursors.delete(userId);
           elm.remove();
         };
+
         const onFadeTimeout = () => {
           elm.style.opacity = 0;
         };
+
         let closeTimeout = setTimeout(onCloseTimeout, 9000);
         let fadeTimeout = setTimeout(onFadeTimeout, 5000);
+
         const update = (p) => {
           elm.style.opacity = 1;
           elm.style.setProperty("transform", `translate(${p[0]}px, ${p[1]}px)`);
@@ -154,11 +158,14 @@
           closeTimeout = setTimeout(onCloseTimeout, 9000);
           fadeTimeout = setTimeout(onFadeTimeout, 5000);
         };
+
         cursors.set(userId, update);
       }
+
       function cancelInput(e) {
         e.stopPropagation();
       }
+
       function disableInput(div) {
         div.addEventListener("mousemove", cancelInput, true);
         div.addEventListener("mousedown", cancelInput, true);
@@ -168,6 +175,7 @@
           vid.style.cursor = null;
         }
       }
+
       function enableInput(div) {
         div.removeEventListener("mousemove", cancelInput, true);
         div.removeEventListener("mousedown", cancelInput, true);

--- a/multicursor/index.html
+++ b/multicursor/index.html
@@ -16,6 +16,7 @@
         position: fixed;
         top: 10px;
         right: 10px;
+        z-index: 1;
       }
 
       .cursor {
@@ -25,7 +26,7 @@
         width: 32px;
         height: 32px;
         pointer-events: none;
-        z-index: 1;
+        z-index: 2;
         transition: opacity 1s ease;
       }
 

--- a/multicursor/index.html
+++ b/multicursor/index.html
@@ -10,8 +10,9 @@
       }
 
       #hb-mini-container {
+        /* 16/9 aspect-ratio */
         width: 500px;
-        height: 240px;
+        height: 281px;
         background-color: black;
         position: fixed;
         top: 10px;


### PR DESCRIPTION
- Fix small hyperbeam container being hidden on less wide windows
- Change small hyperbeam container dimensions to a 16/9 aspect-ratio
- Add a border to small hyperbeam container
- Rename stopCursorEvents to cursorEventsToggle
![image](https://user-images.githubusercontent.com/10477733/203348675-036f8a11-186b-4089-9f49-dfee14d79b81.png)

